### PR TITLE
"sysinfo who" now responds with "No users logged in" instead of

### DIFF
--- a/sysinfo/info.json
+++ b/sysinfo/info.json
@@ -2,9 +2,9 @@
     "AUTHOR" : "kagami#6142",
     "NAME" : "SysInfo",
     "SHORT" : "Display system information",
-    "DESCRIPTION" : "Uses psutil to display cpu, memory, disk and network information",
+    "DESCRIPTION" : "Uses psutil to show various system information for the machine running the bot",
     "REQUIREMENTS": ["psutil"],
     "TAGS" : ["utility", "tools", "system", "info"],
-    "INSTALL_MSG" : "Commands are now in p[sysinfo|sys] group. E.g. [p]sys info, [p]sys df, [p]sys top, etc.",
+    "INSTALL_MSG" : "Thank you for installing SysInfo from RitsuCogs.\nCommands are in [sysinfo|sys] group. [p]help sys",
     "DISABLED" : false
 }

--- a/sysinfo/sysinfo.py
+++ b/sysinfo/sysinfo.py
@@ -679,6 +679,8 @@ class SysInfo:
                 datetime.datetime.fromtimestamp(user.started).strftime("%Y-%m-%d %H:%M"),
                 "(%s)" % user.host if user.host else "",
                 proc_name)
+        if not msg:
+            msg = "No users logged in"
         await self._say(ctx, msg)
         return
 


### PR DESCRIPTION
remaining quiet when no users are logged in. Updated info.json.